### PR TITLE
bugfix in heap_insert()

### DIFF
--- a/heap.h
+++ b/heap.h
@@ -45,7 +45,7 @@ static inline int heap_insert(struct heap_##type *heap, type *el)               
        heap->last_id = 0; /* Wrap around */                                             \
     if (heap->n == 1) {                                                                 \
         memcpy(&heap->top[1], &etmp, sizeof(struct heap_element_##type));               \
-        return 0;                                                                       \
+        return (int)etmp.id;                                                            \
     }                                                                                   \
     for (i = heap->n; ((i > 1) &&                                                       \
                 (heap->top[i / 2].data.orderby > el->orderby)); i /= 2) {               \


### PR DESCRIPTION
When inserting at the first position the returned value is always 0 instead of the timer ID.